### PR TITLE
RCTMGLImageSource.m fixed to be working with local files iOS

### DIFF
--- a/ios/RCTMGL/RCTMGLImageSource.m
+++ b/ios/RCTMGL/RCTMGLImageSource.m
@@ -23,9 +23,20 @@
 
 - (MGLSource *)makeSource
 {
+    NSURL *myURL;
+
+    if ([[_url substringToIndex:4] isEqualToString:@"http"]) {
+        myURL = [NSURL URLWithString:_url];
+    }
+    else
+    {
+        //Default consider it file url path
+        myURL = [NSURL fileURLWithPath:_url];
+    }
+
     return [[MGLImageSource alloc] initWithIdentifier:self.id
                                    coordinateQuad:[self _makeCoordQuad]
-                                   URL:[NSURL URLWithString:_url]];
+                                   URL:myURL];
 }
 
 - (MGLCoordinateQuad)_makeCoordQuad


### PR DESCRIPTION
RCTMGLImageSource.m fixed to be working with local files iOS. Now ImageSource is displaying only HTTP(HTTPS) URLs. But in docs it said that this component may work with `absolute file URL, or local file URL to the source image.` ([link](https://github.com/nitaliano/react-native-mapbox-gl/blob/master/docs/ImageSource.md))